### PR TITLE
fix: correct parameter casing for scroll ID in account stream paginat…

### DIFF
--- a/.github/workflows/ci_workflow.yml
+++ b/.github/workflows/ci_workflow.yml
@@ -35,7 +35,7 @@ jobs:
       GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
     strategy:
       matrix:
-        python-version: [3.7, 3.8, 3.9, "3.10", 3.11]
+        python-version: [3.8, 3.9, "3.10", 3.11]
 
     steps:
     - uses: actions/checkout@v2

--- a/tap_gainsightpx/streams.py
+++ b/tap_gainsightpx/streams.py
@@ -48,7 +48,7 @@ class AccountsStream(GainsightPXStream):
         if self.replication_key:
             params["sort"] = self.replication_key
         if next_page_token:
-            params["scrollID"] = next_page_token
+            params["scrollId"] = next_page_token
 
         return params
 


### PR DESCRIPTION
Correct parameter casing for scroll ID in account stream pagination for avoid "Duplicate request blocked. Please wait before retrying"